### PR TITLE
Added support for nested groups

### DIFF
--- a/function-app/aad-sec-grp-qry/run.ps1
+++ b/function-app/aad-sec-grp-qry/run.ps1
@@ -137,7 +137,7 @@ if ($user) {
     $user
     $userId
     if ($userId) {
-        $groupQuery = "users/$userId/memberOf"
+        $groupQuery = "users/$userId/transitivememberOf"
         $groups = (Get-JsonFromGraph -token $token -strQuery $groupQuery -ver v1.0).displayName
     }
 


### PR DESCRIPTION
By changing the 'memberOf' query in the Graph Call to 'transitivememberOf' we also get the groups the user is a nested member of, which allows for easier / better maintenance of group memberships. 